### PR TITLE
Use X-Forwarded-For for IP if present

### DIFF
--- a/src/Http/Middleware/Analytics.php
+++ b/src/Http/Middleware/Analytics.php
@@ -43,7 +43,7 @@ class Analytics
                 'session_id' => session()->getId(),
                 'path' => $request->path(),
                 'user_agent' => Str::substr($userAgent, 0, 255),
-                'ip' => $request->ip(),
+                'ip' => $request->headers->get('X-Forwarded-For') ? $request->headers->get('X-Forwarded-For') : $request->ip(),
                 'referer' => $request->headers->get('referer'),
             ]);
 


### PR DESCRIPTION
Do a quick check to see if we're behind a proxy which is passing the `X-Forwarded-For` header.

If we're behind that proxy, use the forwarded IP as the `ip` value, otherwise just use the IP that Laravel presents in the request helper.